### PR TITLE
feat: улучшенная проверка vendor deps + set -e для init.sh

### DIFF
--- a/app/init.sh
+++ b/app/init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "Initializing"
 
 USERNAME="www-data"
@@ -24,12 +26,14 @@ mkhomedir_helper $USERNAME
 
 mkdir -p /var/www/bearpass
 
-if [ ! -d "/var/www/bearpass/vendor" ]
-then
-    echo "Downloading vendor deps..."
+vendor_deps_status=$(composer install --no-dev --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --dry-run 2>&1 | grep "Nothing to install, update or remove")
+if [[ -z $vendor_deps_status ]]; then
+    echo "Downloading / updating vendor deps..."
     cd /var/www/bearpass && \
     composer install --no-dev -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist && \
     composer dump-autoload
+else
+    echo "Vendor deps are up-to-date"
 fi
 
 if [ ! -f "/var/www/bearpass/.env" ]

--- a/cron/init.sh
+++ b/cron/init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 USERNAME="www-data"
 GROUPNAME="www-data"
 

--- a/nginx/init.sh
+++ b/nginx/init.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 USERNAME="www-data"
 GROUPNAME="www-data"
 


### PR DESCRIPTION
Если скачивание зависимостей началось, и произошла ошибка, то при всех последующих запусках предыдущая проверка наличия зависимостей `if [ ! -d "/var/www/bearpass/vendor" ]`  будет утверждать, что зависимости есть, хотя не все установлены

Новая проверка позволяет успешно дозагрузить зависимости в случае ошибок на этапе первого запуска, а также позволит восстановить зависимости в случае какого-либо повреждения/удаления файлов зависимостей

Также добавлено классическое `set -e` для init.sh скриптов, чтобы предотвратить неполную инициализацию